### PR TITLE
increase max_old_space_size for github actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -116,6 +116,7 @@ jobs:
           MASIRO_PASS: ${{ secrets.MASIRO_PASS }}
           WENKU8_USER: ${{ secrets.WENKU8_USER }}
           WENKU8_PASS: ${{ secrets.WENKU8_PASS }}
+          NODE_OPTIONS: --max_old_space_size=8192
         run: yarn run ci:cache:list
       - name: Push changes
         if: success()


### PR DESCRIPTION
似乎github actions每天都在OOM, 加點內存跑一跑?